### PR TITLE
Add `clap` to `binaries` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ num-traits = "0.2"
 derive_more = "0.13"
 
 [features]
-binaries = ["structopt", "cargo_metadata", "scroll", "goblin"]
+binaries = ["structopt", "cargo_metadata", "scroll", "goblin", "clap"]


### PR DESCRIPTION
Hi !

`cargo-nro` won't build since it requires `clap` to be built, which is not the case even with `binaries` enabled. It builds successfully with this fix.