### PR TITLE
Update elf dependency to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "elf"
-version = "0.0.12"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9c86cae88373e32c872967c296dcdd3b25771dcc7da1c4ba060b4a68fd8db7"
+checksum = "2ace2c81c1832d02208b8317b90b2de5b3b4f55024b86d3f2ae800353e348fd7"
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ path = "src/bin/cargo-nro.rs"
 required-features = ["binaries"]
 
 [dependencies]
-# there are a lot of breaking changes there, kinda hard to update
-elf = "0.0.12"
+elf = "0.7.1"
 byteorder = "1"
 lz4 = "1.23.1"
 clap = { version = "4.0.32", optional = true, features = ["cargo"] }

--- a/src/format/utils.rs
+++ b/src/format/utils.rs
@@ -2,8 +2,6 @@ use serde::de::{Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use std::fmt;
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
 
 pub fn align(size: usize, padding: usize) -> usize {
     ((size as usize) + padding) & !padding
@@ -19,16 +17,6 @@ pub fn check_string_or_truncate(string: &mut String, name: &str, size: usize) {
         println!("Warning: Truncating {} to 0x{:x}", name, size - 1);
         string.truncate(size);
     }
-}
-
-pub fn get_segment_data(
-    file: &mut File,
-    header: &elf::types::ProgramHeader,
-) -> std::io::Result<Vec<u8>> {
-    let mut data = vec![0; header.filesz as usize];
-    file.seek(SeekFrom::Start(header.offset))?;
-    file.read_exact(&mut data)?;
-    Ok(data)
 }
 
 pub fn compress_lz4(uncompressed_data: &[u8]) -> std::io::Result<Vec<u8>> {


### PR DESCRIPTION
This pulls in a bunch of interface changes to the elf crate. Most of the changes in the diff are just from some type names changing.

The manual parsing of the build-id note is no longer needed, as the elf crate can parse various note formats now.

The ElfBytes type is a partially zero-alloc and lazy-parsing type, so I read the file data once and stashed that in an allocated Vec on the NxoFile then parsed out what was needed to try and keep the diff as simple as possible :)